### PR TITLE
fix: Filter courses by scheduled status in instructor workload

### DIFF
--- a/app.js
+++ b/app.js
@@ -315,7 +315,7 @@ function deleteInstructor(id) {
 
 function getInstructorWorkload(instructorId) {
     return appData.courses
-        .filter(c => c.instructorId === instructorId)
+        .filter(c => c.instructorId === instructorId && isCourseScheduled(c.id))
         .reduce((sum, c) => sum + c.credits, 0);
 }
 


### PR DESCRIPTION
Closes #5 

This pull request makes a small update to the instructor workload calculation to ensure only scheduled courses are included. The change adds a check to include only courses that are scheduled when calculating an instructor's workload.